### PR TITLE
QWeather 5min 降水量要*20才能匹配mmph单位

### DIFF
--- a/src/class/QWeather.mjs
+++ b/src/class/QWeather.mjs
@@ -216,7 +216,7 @@ export default class QWeather {
                             const minute = {
                                 "perceivedPrecipitationIntensity": 0,
                                 "precipitationChance": 0,
-                                "precipitationIntensity": Number.parseFloat(minutely.precip),
+                                "precipitationIntensity": Number.parseFloat(minutely.precip) * 20,
                                 "startTime": new Date(minutely.fxTime) / 1000,
                             };
                             let minutes = [{ ...minute }, { ...minute }, { ...minute }, { ...minute }, { ...minute }];


### PR DESCRIPTION
原本大雨一直显示为小雨，查了文档才知道和风天气的每分钟降水量返回是毫米每5分钟，故需修正到毫米每小时，乘20倍