### PR TITLE
fix(ConvertAirQuality): log message for 'NONE' scale case and return body

### DIFF
--- a/src/response.js
+++ b/src/response.js
@@ -242,7 +242,8 @@ function ConvertAirQuality(body, Settings) {
 	let airQuality;
 	switch (Settings?.AQI?.Local?.Scale) {
 		case "NONE":
-			break;
+			Console.log("✅ ConvertAirQuality: Scale is NONE, not converting.");
+			return body;
 		case "HJ_633":
 		case "EPA_NowCast":
 		case "WAQI_InstantCast":


### PR DESCRIPTION
修复了当AQI.Local.Scale设置为NONE时，因TypeError: undefined is not an object (evaluating 'i.index')脚本运行中断。