### PR TITLE
fix(WeatherKit2): preserve iOS 27 root products

### DIFF
--- a/src/class/ColorfulClouds.mjs
+++ b/src/class/ColorfulClouds.mjs
@@ -173,7 +173,7 @@ export default class ColorfulClouds {
                             const timeStamp = (Date.now() / 1000) | 0;
                             const metadata = {
                                 attributionUrl: "https://www.caiyunapp.com/h5",
-                                expireTime: timeStamp + 60 * 60,
+                                expireTime: timeStamp + ForecastNextHour.ExpirationInterval,
                                 language: "zh-CN", // `${this.language}-${this.country}`, // body?.lang,
                                 latitude: body?.location?.[0],
                                 longitude: body?.location?.[1],

--- a/src/class/ForecastNextHour.mjs
+++ b/src/class/ForecastNextHour.mjs
@@ -2,8 +2,11 @@ import { Console } from "@nsnanocat/util";
 
 export default class ForecastNextHour {
     Name = "ForecastNextHour";
-    Version = "v1.6.3";
+    Version = "v1.6.4";
     Author = "iRingo";
+
+    // iOS 27 hides NextHour data once its metadata is more than 15 minutes old.
+    static ExpirationInterval = 10 * 60;
 
     static #Configs = {
         Pollutants: {

--- a/src/class/QWeather.mjs
+++ b/src/class/QWeather.mjs
@@ -337,7 +337,7 @@ export default class QWeather {
                     forecastNextHour = {
                         metadata: {
                             attributionUrl: body?.fxLink,
-                            expireTime: timeStamp + 60 * 60,
+                            expireTime: timeStamp + ForecastNextHour.ExpirationInterval,
                             language: "zh-CN", // `${this.language}-${this.country}`, // body?.lang,
                             latitude: this.latitude,
                             longitude: this.longitude,

--- a/src/class/WeatherKit2.mjs
+++ b/src/class/WeatherKit2.mjs
@@ -1,9 +1,39 @@
 import { Console } from "@nsnanocat/util";
+import seedFlatBufferRootOverlay from "../function/flatBufferRootOverlay.mjs";
 import * as WK2 from "../proto/apple/wk2.js";
 
 export default class WeatherKit2 {
     static Name = "WeatherKit2";
     static Version = "1.2.1";
+    static InjectableRootSlots = new Map([
+        ["airQuality", 0],
+        ["currentWeather", 1],
+        ["forecastDaily", 2],
+        ["forecastHourly", 3],
+        ["forecastNextHour", 4],
+    ]);
+
+    /**
+     * Re-encode injected root products while retaining every untouched root
+     * product as an opaque table. This keeps products introduced by newer
+     * WeatherKit schemas from disappearing during a decode/encode round trip.
+     */
+    static encodeRootOverlay(builder, source, dataSets = [], data = {}) {
+        const dataSetList = [...dataSets];
+        Console.info("☑️ WeatherKit2.encodeRootOverlay", `dataSets: ${dataSetList}`);
+        const overlay = seedFlatBufferRootOverlay(builder, source);
+        const replacements = new Map();
+
+        for (const dataSet of dataSetList) {
+            const slot = WeatherKit2.InjectableRootSlots.get(dataSet);
+            if (slot !== undefined && data?.[dataSet]) replacements.set(slot, WeatherKit2.encode(builder, dataSet, data[dataSet]));
+        }
+
+        const offset = overlay.createRoot(replacements);
+        Console.info("✅ WeatherKit2.encodeRootOverlay", `replaced slots: ${[...replacements.keys()]}`);
+        return offset;
+    }
+
     static encode(builder, dataSet = "all", data = {}) {
         Console.info("☑️ WeatherKit2.encode", `dataSet: ${dataSet}`);
         let offset;

--- a/src/function/flatBufferRootOverlay.mjs
+++ b/src/function/flatBufferRootOverlay.mjs
@@ -1,0 +1,118 @@
+const ROOT_OFFSET_SIZE = 4;
+const VTABLE_HEADER_SIZE = 4;
+const VTABLE_ENTRY_SIZE = 2;
+const OFFSET_FIELD_SIZE = 4;
+const MAX_SCALAR_ALIGNMENT = 8;
+
+/**
+ * Seed a FlatBuffers Builder with an existing buffer and return a root-table
+ * copy-on-write context.
+ *
+ * The source bytes stay together in an aligned Builder payload, so their
+ * relative offsets remain valid. Encode replacement tables with the same
+ * Builder, then pass their offsets to createRoot as
+ * Map<rootSlot, builderOffset>.
+ *
+ * @param {import("flatbuffers").Builder} builder
+ * @param {import("flatbuffers").ByteBuffer} source
+ */
+export default function seedFlatBufferRootOverlay(builder, source) {
+    if (builder.offset() !== 0) throw new Error("FlatBuffer root overlay must seed an empty Builder");
+
+    const root = inspectOffsetTableRoot(source);
+    const sourceBytes = source.bytes().subarray(root.sourceStart).slice();
+    const sourceLength = sourceBytes.length;
+
+    // Store the original buffer as an aligned byte vector. The vector prefix is
+    // intentionally unreachable; its payload is an opaque object graph whose
+    // internal relative offsets remain valid after the constant relocation.
+    builder.startVector(1, sourceLength, MAX_SCALAR_ALIGNMENT);
+    for (let index = sourceLength - 1; index >= 0; index--) builder.writeInt8(sourceBytes[index]);
+    const sourceVectorOffset = builder.endVector();
+    const sourceStartOffset = sourceVectorOffset - OFFSET_FIELD_SIZE;
+
+    const opaqueOffsets = new Map(root.presentSlots.map(({ slot, tablePosition }) => [slot, sourceStartOffset - (tablePosition - root.sourceStart)]));
+
+    return {
+        presentSlots: new Set(opaqueOffsets.keys()),
+        sourceSlotCount: root.slotCount,
+
+        /**
+         * Create a new root table that points to the untouched source tables
+         * unless a replacement Builder offset is provided for that slot.
+         *
+         * @param {Map<number, number>} replacements
+         * @returns {number} root table offset for Builder.finish()
+         */
+        createRoot(replacements = new Map()) {
+            if (!(replacements instanceof Map)) throw new TypeError("FlatBuffer root replacements must be a Map");
+
+            let slotCount = root.slotCount;
+            for (const [slot, offset] of replacements) {
+                if (!Number.isSafeInteger(slot) || slot < 0) throw new RangeError(`Invalid FlatBuffer root slot: ${slot}`);
+                if (!Number.isSafeInteger(offset) || offset <= 0 || offset > builder.offset()) throw new RangeError(`Invalid Builder offset for root slot ${slot}: ${offset}`);
+                slotCount = Math.max(slotCount, slot + 1);
+            }
+
+            builder.startObject(slotCount);
+            for (let slot = 0; slot < slotCount; slot++) {
+                const offset = replacements.get(slot) ?? opaqueOffsets.get(slot);
+                if (offset) builder.addFieldOffset(slot, offset, 0);
+            }
+            return builder.endObject();
+        },
+    };
+}
+
+function inspectOffsetTableRoot(source) {
+    const sourceStart = source.position();
+    const sourceEnd = source.capacity();
+    ensureRange(sourceStart, ROOT_OFFSET_SIZE, sourceStart, sourceEnd, "root offset");
+
+    const rootPosition = sourceStart + source.readUint32(sourceStart);
+    const rootTable = inspectTable(source, rootPosition, sourceStart, sourceEnd, "root table");
+    const slotCount = (rootTable.vtableLength - VTABLE_HEADER_SIZE) / VTABLE_ENTRY_SIZE;
+    const presentSlots = [];
+
+    for (let slot = 0; slot < slotCount; slot++) {
+        const fieldOffset = source.readUint16(rootTable.vtablePosition + VTABLE_HEADER_SIZE + slot * VTABLE_ENTRY_SIZE);
+        if (fieldOffset === 0) continue;
+        if (fieldOffset < ROOT_OFFSET_SIZE || fieldOffset + OFFSET_FIELD_SIZE > rootTable.objectLength) {
+            throw new Error(`FlatBuffer root slot ${slot} has an invalid field offset: ${fieldOffset}`);
+        }
+
+        const fieldPosition = rootPosition + fieldOffset;
+        ensureRange(fieldPosition, OFFSET_FIELD_SIZE, sourceStart, sourceEnd, `root slot ${slot}`);
+        const relativeOffset = source.readUint32(fieldPosition);
+        if (relativeOffset === 0) throw new Error(`FlatBuffer root slot ${slot} has a null table offset`);
+
+        const tablePosition = fieldPosition + relativeOffset;
+        inspectTable(source, tablePosition, sourceStart, sourceEnd, `root slot ${slot} table`);
+        presentSlots.push({ slot, tablePosition });
+    }
+
+    return { presentSlots, slotCount, sourceStart };
+}
+
+function inspectTable(source, tablePosition, sourceStart, sourceEnd, label) {
+    ensureRange(tablePosition, ROOT_OFFSET_SIZE, sourceStart, sourceEnd, label);
+    const vtablePosition = tablePosition - source.readInt32(tablePosition);
+    ensureRange(vtablePosition, VTABLE_HEADER_SIZE, sourceStart, sourceEnd, `${label} vtable`);
+
+    const vtableLength = source.readUint16(vtablePosition);
+    const objectLength = source.readUint16(vtablePosition + VTABLE_ENTRY_SIZE);
+    if (vtableLength < VTABLE_HEADER_SIZE || vtableLength % VTABLE_ENTRY_SIZE !== 0) {
+        throw new Error(`${label} has an invalid vtable length: ${vtableLength}`);
+    }
+    if (objectLength < ROOT_OFFSET_SIZE) throw new Error(`${label} has an invalid object length: ${objectLength}`);
+
+    ensureRange(vtablePosition, vtableLength, sourceStart, sourceEnd, `${label} vtable`);
+    ensureRange(tablePosition, objectLength, sourceStart, sourceEnd, label);
+    return { objectLength, vtableLength, vtablePosition };
+}
+
+function ensureRange(position, length, start, end, label) {
+    if (!Number.isSafeInteger(position) || !Number.isSafeInteger(length) || position < start || length < 0 || position + length > end) {
+        throw new Error(`${label} is outside the FlatBuffer`);
+    }
+}

--- a/src/process/Response.dev.mjs
+++ b/src/process/Response.dev.mjs
@@ -103,6 +103,8 @@ export async function Response($request, $response) {
                                     await matchEnum.init();
                                 }
                                 const parameters = parseWeatherKitURL(url);
+                                const originalForecastNextHour = body.forecastNextHour;
+                                const replacementDataSets = new Set();
                                 const enviroments = {
                                     colorfulClouds: new ColorfulClouds(parameters, Settings?.API?.ColorfulClouds?.Token || "Y2FpeXVuX25vdGlmeQ=="),
                                     qWeather: new QWeather(parameters, Settings?.API?.QWeather?.Token, Settings?.API?.QWeather?.Host),
@@ -117,7 +119,9 @@ export async function Response($request, $response) {
                                                 if (Settings?.LogLevel === "DEBUG" || Settings?.LogLevel === "ALL") {
                                                     matchEnum.airQuality();
                                                 }
+                                                const originalAirQuality = body.airQuality;
                                                 body.airQuality = await InjectAirQuality(body.airQuality, Settings, Caches, enviroments);
+                                                if (body.airQuality !== originalAirQuality) replacementDataSets.add(dataSet);
                                                 break;
                                             }
                                             case "currentWeather": {
@@ -125,18 +129,27 @@ export async function Response($request, $response) {
                                                     matchEnum.weatherCondition();
                                                     matchEnum.pressureTrend();
                                                 }
+                                                const originalCurrentWeather = body.currentWeather;
+                                                const originalProviderLogo = originalCurrentWeather?.metadata?.providerLogo;
                                                 body.currentWeather = await InjectCurrentWeather(body.currentWeather, Settings, enviroments);
                                                 if (body?.currentWeather?.metadata?.providerName && !body?.currentWeather?.metadata?.providerLogo) body.currentWeather.metadata.providerLogo = providerNameToLogo(body?.currentWeather?.metadata?.providerName, "v2");
+                                                if (body.currentWeather !== originalCurrentWeather || body.currentWeather?.metadata?.providerLogo !== originalProviderLogo) replacementDataSets.add(dataSet);
                                                 break;
                                             }
                                             case "forecastDaily": {
+                                                const originalMetadata = body.forecastDaily?.metadata;
+                                                const originalProviderLogo = originalMetadata?.providerLogo;
                                                 body.forecastDaily = await InjectForecastDaily(body.forecastDaily, Settings, enviroments);
                                                 if (body?.forecastDaily?.metadata?.providerName && !body?.forecastDaily?.metadata?.providerLogo) body.forecastDaily.metadata.providerLogo = providerNameToLogo(body?.forecastDaily?.metadata?.providerName, "v2");
+                                                if (body.forecastDaily?.metadata !== originalMetadata || body.forecastDaily?.metadata?.providerLogo !== originalProviderLogo) replacementDataSets.add(dataSet);
                                                 break;
                                             }
                                             case "forecastHourly": {
+                                                const originalMetadata = body.forecastHourly?.metadata;
+                                                const originalProviderLogo = originalMetadata?.providerLogo;
                                                 body.forecastHourly = await InjectForecastHourly(body.forecastHourly, Settings, enviroments);
                                                 if (body?.forecastHourly?.metadata?.providerName && !body?.forecastHourly?.metadata?.providerLogo) body.forecastHourly.metadata.providerLogo = providerNameToLogo(body?.forecastHourly?.metadata?.providerName, "v2");
+                                                if (body.forecastHourly?.metadata !== originalMetadata || body.forecastHourly?.metadata?.providerLogo !== originalProviderLogo) replacementDataSets.add(dataSet);
                                                 break;
                                             }
                                             case "forecastNextHour": {
@@ -146,7 +159,10 @@ export async function Response($request, $response) {
                                                     matchEnum.forecastToken();
                                                 }
                                                 body.forecastNextHour = await InjectForecastNextHour(body.forecastNextHour, Settings, enviroments);
-                                                if (body?.forecastNextHour?.metadata?.providerName && !body?.forecastNextHour?.metadata?.providerLogo) body.forecastNextHour.metadata.providerLogo = providerNameToLogo(body?.forecastNextHour?.metadata?.providerName, "v2");
+                                                if (body.forecastNextHour !== originalForecastNextHour) {
+                                                    if (body?.forecastNextHour?.metadata?.providerName && !body?.forecastNextHour?.metadata?.providerLogo) body.forecastNextHour.metadata.providerLogo = providerNameToLogo(body?.forecastNextHour?.metadata?.providerName, "v2");
+                                                    replacementDataSets.add(dataSet);
+                                                }
                                                 break;
                                             }
                                             case "news": {
@@ -188,7 +204,7 @@ export async function Response($request, $response) {
                                         }
                                     }),
                                 );
-                                const WeatherData = WeatherKit2.encode(Builder, "all", body);
+                                const WeatherData = WeatherKit2.encodeRootOverlay(Builder, ByteBuffer, replacementDataSets, body);
                                 Builder.finish(WeatherData);
                                 break;
                             }

--- a/src/process/Response.mjs
+++ b/src/process/Response.mjs
@@ -85,6 +85,8 @@ export async function Response($request, $response) {
                             if (url.pathname.startsWith("/api/v2/weather/")) {
                                 body = WeatherKit2.decode(ByteBuffer, "all");
                                 const parameters = parseWeatherKitURL(url);
+                                const originalForecastNextHour = body.forecastNextHour;
+                                const replacementDataSets = new Set();
                                 const enviroments = {
                                     colorfulClouds: new ColorfulClouds(parameters, Settings?.API?.ColorfulClouds?.Token || "Y2FpeXVuX25vdGlmeQ=="),
                                     qWeather: new QWeather(parameters, Settings?.API?.QWeather?.Token, Settings?.API?.QWeather?.Host),
@@ -96,27 +98,41 @@ export async function Response($request, $response) {
                                     parameters.dataSets.map(async dataSet => {
                                         switch (dataSet) {
                                             case "airQuality": {
+                                                const originalAirQuality = body.airQuality;
                                                 body.airQuality = await InjectAirQuality(body.airQuality, Settings, Caches, enviroments);
+                                                if (body.airQuality !== originalAirQuality) replacementDataSets.add(dataSet);
                                                 break;
                                             }
                                             case "currentWeather": {
+                                                const originalCurrentWeather = body.currentWeather;
+                                                const originalProviderLogo = originalCurrentWeather?.metadata?.providerLogo;
                                                 body.currentWeather = await InjectCurrentWeather(body.currentWeather, Settings, enviroments);
                                                 if (body?.currentWeather?.metadata?.providerName && !body?.currentWeather?.metadata?.providerLogo) body.currentWeather.metadata.providerLogo = providerNameToLogo(body?.currentWeather?.metadata?.providerName, "v2");
+                                                if (body.currentWeather !== originalCurrentWeather || body.currentWeather?.metadata?.providerLogo !== originalProviderLogo) replacementDataSets.add(dataSet);
                                                 break;
                                             }
                                             case "forecastDaily": {
+                                                const originalMetadata = body.forecastDaily?.metadata;
+                                                const originalProviderLogo = originalMetadata?.providerLogo;
                                                 body.forecastDaily = await InjectForecastDaily(body.forecastDaily, Settings, enviroments);
                                                 if (body?.forecastDaily?.metadata?.providerName && !body?.forecastDaily?.metadata?.providerLogo) body.forecastDaily.metadata.providerLogo = providerNameToLogo(body?.forecastDaily?.metadata?.providerName, "v2");
+                                                if (body.forecastDaily?.metadata !== originalMetadata || body.forecastDaily?.metadata?.providerLogo !== originalProviderLogo) replacementDataSets.add(dataSet);
                                                 break;
                                             }
                                             case "forecastHourly": {
+                                                const originalMetadata = body.forecastHourly?.metadata;
+                                                const originalProviderLogo = originalMetadata?.providerLogo;
                                                 body.forecastHourly = await InjectForecastHourly(body.forecastHourly, Settings, enviroments);
                                                 if (body?.forecastHourly?.metadata?.providerName && !body?.forecastHourly?.metadata?.providerLogo) body.forecastHourly.metadata.providerLogo = providerNameToLogo(body?.forecastHourly?.metadata?.providerName, "v2");
+                                                if (body.forecastHourly?.metadata !== originalMetadata || body.forecastHourly?.metadata?.providerLogo !== originalProviderLogo) replacementDataSets.add(dataSet);
                                                 break;
                                             }
                                             case "forecastNextHour": {
                                                 body.forecastNextHour = await InjectForecastNextHour(body.forecastNextHour, Settings, enviroments);
-                                                if (body?.forecastNextHour?.metadata?.providerName && !body?.forecastNextHour?.metadata?.providerLogo) body.forecastNextHour.metadata.providerLogo = providerNameToLogo(body?.forecastNextHour?.metadata?.providerName, "v2");
+                                                if (body.forecastNextHour !== originalForecastNextHour) {
+                                                    if (body?.forecastNextHour?.metadata?.providerName && !body?.forecastNextHour?.metadata?.providerLogo) body.forecastNextHour.metadata.providerLogo = providerNameToLogo(body?.forecastNextHour?.metadata?.providerName, "v2");
+                                                    replacementDataSets.add(dataSet);
+                                                }
                                                 break;
                                             }
                                             default:
@@ -124,7 +140,7 @@ export async function Response($request, $response) {
                                         }
                                     }),
                                 );
-                                const WeatherData = WeatherKit2.encode(Builder, "all", body);
+                                const WeatherData = WeatherKit2.encodeRootOverlay(Builder, ByteBuffer, replacementDataSets, body);
                                 Builder.finish(WeatherData);
                                 break;
                             }

--- a/tests/flatBufferRootOverlay.test.mjs
+++ b/tests/flatBufferRootOverlay.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Builder, ByteBuffer } from "flatbuffers";
+import seedFlatBufferRootOverlay from "../src/function/flatBufferRootOverlay.mjs";
+
+test("root overlay preserves opaque tables while replacing and adding slots", () => {
+    const originalBuilder = new Builder(256);
+    const originalKnown = createLeaf(originalBuilder, 11, "known-old");
+    const opaquePeriodic = createLeaf(originalBuilder, 66, "opaque-periodic");
+    const opaqueLeaf = createLeaf(originalBuilder, 77, "opaque-nested-string");
+    const opaqueTable = createContainer(originalBuilder, opaqueLeaf);
+    originalBuilder.startObject(16);
+    originalBuilder.addFieldOffset(0, originalKnown, 0);
+    originalBuilder.addFieldOffset(12, opaquePeriodic, 0);
+    originalBuilder.addFieldOffset(15, opaqueTable, 0);
+    const originalRoot = originalBuilder.endObject();
+    originalBuilder.finish(originalRoot);
+    const originalBytes = originalBuilder.asUint8Array().slice();
+
+    const builder = new Builder(16);
+    const overlay = seedFlatBufferRootOverlay(builder, new ByteBuffer(originalBytes));
+    const replacementKnown = createLeaf(builder, 22, "known-new");
+    const addedTable = createLeaf(builder, 33, "added-slot");
+    const root = overlay.createRoot(
+        new Map([
+            [0, replacementKnown],
+            [4, addedTable],
+        ]),
+    );
+    builder.finish(root);
+
+    const outputBytes = builder.asUint8Array();
+    assert.notEqual(Buffer.from(outputBytes).indexOf(originalBytes), -1);
+    const output = new ByteBuffer(outputBytes);
+    const outputRoot = output.__indirect(output.position());
+    const known = tableAt(output, outputRoot, 0);
+    const added = tableAt(output, outputRoot, 4);
+    const periodic = tableAt(output, outputRoot, 12);
+    const opaque = tableAt(output, outputRoot, 15);
+    const nestedOpaque = tableAt(output, opaque, 0);
+
+    assert.deepEqual(readLeaf(output, known), { text: "known-new", value: 22 });
+    assert.deepEqual(readLeaf(output, added), { text: "added-slot", value: 33 });
+    assert.deepEqual(readLeaf(output, periodic), { text: "opaque-periodic", value: 66 });
+    assert.deepEqual(readLeaf(output, nestedOpaque), { text: "opaque-nested-string", value: 77 });
+    assert.equal(overlay.sourceSlotCount, 16);
+    assert.deepEqual([...overlay.presentSlots], [0, 12, 15]);
+});
+
+test("root overlay rejects a present root slot that is not an offset table", () => {
+    const builder = new Builder(64);
+    builder.startObject(2);
+    builder.addFieldInt32(1, 123, 0);
+    const root = builder.endObject();
+    builder.finish(root);
+
+    assert.throws(() => seedFlatBufferRootOverlay(new Builder(), new ByteBuffer(builder.asUint8Array())), /root slot 1 table/);
+});
+
+function createLeaf(builder, value, text) {
+    const textOffset = builder.createString(text);
+    builder.startObject(2);
+    builder.addFieldInt32(0, value, 0);
+    builder.addFieldOffset(1, textOffset, 0);
+    return builder.endObject();
+}
+
+function createContainer(builder, nestedOffset) {
+    builder.startObject(1);
+    builder.addFieldOffset(0, nestedOffset, 0);
+    return builder.endObject();
+}
+
+function tableAt(byteBuffer, table, slot) {
+    const fieldOffset = byteBuffer.__offset(table, 4 + slot * 2);
+    return fieldOffset ? byteBuffer.__indirect(table + fieldOffset) : 0;
+}
+
+function readLeaf(byteBuffer, table) {
+    const valueOffset = byteBuffer.__offset(table, 4);
+    const textOffset = byteBuffer.__offset(table, 6);
+    return {
+        text: textOffset ? byteBuffer.__string(table + textOffset) : null,
+        value: valueOffset ? byteBuffer.readInt32(table + valueOffset) : 0,
+    };
+}


### PR DESCRIPTION
Refs #68

## 根因

中国大陆的 availability 响应默认不开放 `forecastNextHour`，插件需要先解锁该产品。解锁后，Apple 的完整响应在有分钟级预报时可能直接返回 NextHour；没有返回时，插件再用彩云天气或和风天气补齐。因此这里既要保留 Apple 原生 NextHour，也要支持缺失时注入。

iOS 27 Weather.app 的完整请求包含以下产品：

```text
airQuality,currentWeather,dataNotice,forecastDaily,forecastHourly,
forecastNextHour,forecastPeriodic,highlights,news,historicalComparisons,
weatherAlerts,weatherChanges
```

线上响应的 `Weather` root vtable 有 16 个 slots。仓库当前生成的 `WK2.Weather` 只定义了 10 个，`WeatherKit2.encode(..., "all")` 也只重建这 10 个。现有的 `decode -> inject -> encode` 流程会丢掉 `forecastPeriodic`、`dataNotice`、`highlights` 等新产品。

WeatherDataService 在 HTTP 拦截前已经根据原请求确定预期产品。收到缺字段的重编码响应后，它会先缓存部分产品，随后判定整批数据无效并清空缓存：

```text
Invalid weather data from WDS; clearing cache
MissingProductError(product: WeatherDaemon.WeatherProduct.forecastPeriodic)
```

这也解释了两种看似矛盾的现象：

- 从 URL 删除 `forecastPeriodic` 没有效果，因为 daemon 的预期集合没有改变。
- 对完整响应直接 `$done({})` 可以恢复 NextHour 和 periodic forecast，但同一响应里的 `InjectAirQuality` 也被跳过，后到的原生 `HJ6332012.2604` 会覆盖插件计算的 `EU.EAQI.2414`。

NextHour 的 60 分钟缓存还有一个独立问题。iOS 27 在数据超过约 15 分钟时会判定 minute forecast stale，但 Weather 仍认为 60 分钟缓存有效，不会重新请求。本 PR 同时把第三方 NextHour 的 TTL 改为 10 分钟，使其在 stale cutoff 前刷新。

## 修改

新增 root-level copy-on-write 编码流程：

1. 把原始 FlatBuffer 作为对齐的 opaque object graph 保存在同一个 Builder 中。
2. 枚举并校验 root vtable；未修改的 slots 继续引用原始 table。
3. 只重新编码插件实际修改的 `airQuality`、current/daily/hourly weather，以及缺失时注入的 `forecastNextHour`。
4. 创建新的 root table，将 replacement offsets 和 opaque offsets 合并。

这个实现不需要猜测 iOS 27 新产品的内部 schema。Apple 原生 NextHour 已存在时也不会被旧 codec 重编码；只有插件实际生成了新 NextHour，才会写入 slot 4。如果以后 root 出现非 table 字段，校验会直接失败，响应脚本保留原始 body。

## 验证

- `node --test tests/flatBufferRootOverlay.test.mjs`：2/2 通过。覆盖 16-slot root、替换 slot 0、补 slot 4、保留 opaque slots 12/15 及嵌套字符串，并验证非 table root field 会 fail closed。
- 真实 iOS 27 full response：原包 41,472 bytes，present slots 为 `[0,1,2,3,5,6,7,8,12,15]`。overlay 后 slots 12/15 仍可解析，原始 object graph 逐字节保留。
- 三组离线 VM：
  - 缺 slot 4 时只注入 NextHour；
  - `Weather.Provider=WeatherKit` 时只替换实际变化的 AQ，slots 1/2/3/4 保持 opaque；
  - 默认 ColorfulClouds 时替换 slots 1/2/3，Apple 原生 slot 4 保持 opaque。
- iOS 27 真机，深圳南山：完整 12-product 请求命中开发版脚本；日志连续得到 `EU.EAQI.2414`、`Successfully built minute forecast`、`Successfully built periodic forecast` 和 `Successfully built highlights`。同一轮没有 `MissingProductError`、`Invalid weather data from WDS` 或 aggregate cache clearing。
- `node --check`、Biome 和 `git diff --check` 通过。Biome 仅报告 `Response*.mjs` 原有的两个 unused-import warnings。

真机测试使用固定地址的 [Loon 开发版插件](https://gist.githubusercontent.com/hhh2210/dc95c3e9ecc870a78138d0a67942d037/raw/AppleWeatherEnhancer-iOS27-Dev.lpx)。

完整 `npm ci` / bundle build 在外部贡献者环境中仍不可用：`@nsnanocat/util` 需要 GitHub Packages 的 `read:packages` 权限，`NSRingo/proto` 子模块也不可见。测试 bundle 以 v3.1.0 release bundle 为基线做机械转换，并固定校验输入 SHA-256；转换脚本、产物和真实响应 VM 均通过 `node --check`。

<img width="776" height="1650" alt="iOS 27 下一小时降水" src="https://github.com/user-attachments/assets/cd04383e-a99b-42c7-9144-a3e75a90e9f0" />
