### PR TITLE
fix(ForecastNextHour): handle multi-segment precipitation conditions

### DIFF
--- a/src/class/ForecastNextHour.mjs
+++ b/src/class/ForecastNextHour.mjs
@@ -2,7 +2,7 @@ import { Console } from "@nsnanocat/util";
 
 export default class ForecastNextHour {
     Name = "ForecastNextHour";
-    Version = "v1.6.4";
+    Version = "v1.6.5";
     Author = "iRingo";
 
     // iOS 27 hides NextHour data once its metadata is more than 15 minutes old.
@@ -255,257 +255,90 @@ export default class ForecastNextHour {
     static Condition(summaries = []) {
         Console.info("☑️ Condition");
         const Conditions = [];
-        // 先通过 summaries 定基调
-        switch (summaries.map(summary => summary.clear).join("|")) {
-            case "true": {
-                // 全程 CLEAR, 无降水, 是 CLEAR
-                const CLEAR = summaries[0]; // CLEAR 时期
-                // CLEAR 期间显示为 CLEAR
-                Conditions.push({
-                    beginCondition: CLEAR.maxCondition,
-                    endCondition: CLEAR.maxCondition,
-                    forecastToken: "CLEAR",
-                    parameters: [],
-                    startTime: CLEAR.startTime,
-                    endTime: 0, // CLEAR 期间
-                });
-                break;
+        if (!summaries.length) {
+            Console.debug(`Conditions: ${JSON.stringify(Conditions, null, 2)}`);
+            Console.info("✅ Condition");
+            return Conditions;
+        }
+
+        // Summary() emits alternating clear/precipitation runs. Preserve the
+        // previous empty result for unsupported direct callers that violate it.
+        for (let i = 1; i < summaries.length; i++) {
+            if (summaries[i - 1].clear === summaries[i].clear) {
+                Console.warn("Condition", `Adjacent summaries have the same clear state at indexes ${i - 1} and ${i}`);
+                Console.debug(`Conditions: ${JSON.stringify(Conditions, null, 2)}`);
+                Console.info("✅ Condition");
+                return Conditions;
             }
-            case "false": {
-                // 全程 RAIN, 有降水, 是 CONSTANT
-                const CONSTANT = summaries[0]; // CONSTANT 时期
-                // CONSTANT 期间显示为 CONSTANT
+        }
+
+        for (let i = 0; i < summaries.length; i++) {
+            const current = summaries[i];
+            const next = summaries[i + 1];
+            const afterNext = summaries[i + 2];
+
+            if (current.clear) {
+                if (!next) {
+                    Conditions.push({
+                        beginCondition: current.maxCondition,
+                        endCondition: current.maxCondition,
+                        forecastToken: "CLEAR",
+                        parameters: [],
+                        startTime: current.startTime,
+                        endTime: 0,
+                    });
+                } else if (afterNext) {
+                    Conditions.push({
+                        beginCondition: next.maxCondition,
+                        endCondition: next.maxCondition,
+                        forecastToken: "START_STOP",
+                        parameters: [
+                            { date: next.startTime, type: "FIRST_AT" },
+                            { date: next.endTime, type: "SECOND_AT" },
+                        ],
+                        startTime: current.startTime,
+                        endTime: current.endTime,
+                    });
+                } else {
+                    Conditions.push({
+                        beginCondition: next.maxCondition,
+                        endCondition: next.maxCondition,
+                        forecastToken: "START",
+                        parameters: [{ date: next.startTime, type: "FIRST_AT" }],
+                        startTime: current.startTime,
+                        endTime: current.endTime,
+                    });
+                }
+            } else if (!next) {
                 Conditions.push({
-                    beginCondition: CONSTANT.maxCondition,
-                    endCondition: CONSTANT.maxCondition,
+                    beginCondition: current.maxCondition,
+                    endCondition: current.maxCondition,
                     forecastToken: "CONSTANT",
                     parameters: [],
-                    startTime: CONSTANT.startTime, // CONSTANT 期间
-                    endTime: 0, // CONSTANT 期间
+                    startTime: current.startTime,
+                    endTime: 0,
                 });
-                break;
-            }
-            case "true|false": {
-                // 先 CLEAR 后降水, 是 START
-                const CLEAR = summaries[0]; // START 时期
-                const START = summaries[1]; // CONSTANT 时期
-                // CLEAR 期间显示为 START
+            } else if (afterNext) {
                 Conditions.push({
-                    beginCondition: START.maxCondition,
-                    endCondition: START.maxCondition,
-                    forecastToken: "START",
-                    parameters: [{ date: START.startTime, type: "FIRST_AT" }], // 降水开始时
-                    startTime: CLEAR.startTime, // CLEAR 期间
-                    endTime: CLEAR.endTime, // CLEAR 期间
-                });
-                // START 期间显示为 CONSTANT
-                Conditions.push({
-                    beginCondition: START.maxCondition,
-                    endCondition: START.maxCondition,
-                    forecastToken: "CONSTANT",
-                    parameters: [],
-                    startTime: START.startTime, // START 期间
-                    endTime: 0, // START 期间
-                });
-                break;
-            }
-            case "false|true": {
-                // 先降水后 CLEAR, 是 STOP
-                const STOP = summaries[0]; // STOP 时期
-                const CLEAR = summaries[1]; // CLEAR 时期
-                // STOP 期间显示为 STOP
-                Conditions.push({
-                    beginCondition: STOP.maxCondition,
-                    endCondition: STOP.maxCondition,
-                    forecastToken: "STOP",
-                    parameters: [{ date: STOP.endTime, type: "FIRST_AT" }], // 降水结束时
-                    startTime: STOP.startTime, // STOP 期间
-                    endTime: STOP.endTime, // STOP 期间
-                });
-                // CLEAR 期间显示为 CLEAR
-                Conditions.push({
-                    beginCondition: CLEAR.maxCondition,
-                    endCondition: CLEAR.maxCondition,
-                    forecastToken: "CLEAR",
-                    parameters: [],
-                    startTime: CLEAR.startTime, // CLEAR 期间
-                    endTime: 0, // CLEAR 期间
-                });
-                break;
-            }
-            case "false|true|false": {
-                // 先降水后 CLEAR, 再降水, 是 STOP_START
-                const STOP = summaries[0]; // STOP 时期
-                const CLEAR = summaries[1]; // START 时期
-                const START = summaries[2]; // START 时期
-                // STOP 期间显示为 STOP_START
-                Conditions.push({
-                    beginCondition: STOP.maxCondition, // 第一次降水降水开始时
-                    endCondition: START.maxCondition, // 第一次降水降水结束时
+                    beginCondition: current.maxCondition,
+                    endCondition: afterNext.maxCondition,
                     forecastToken: "STOP_START",
                     parameters: [
-                        { date: STOP.endTime, type: "FIRST_AT" }, // 第一次降水结束时
-                        { date: START.startTime, type: "SECOND_AT" }, // 第二次降水开始时
+                        { date: current.endTime, type: "FIRST_AT" },
+                        { date: afterNext.startTime, type: "SECOND_AT" },
                     ],
-                    startTime: STOP.startTime, // STOP 期间
-                    endTime: STOP.endTime, // STOP 期间
+                    startTime: current.startTime,
+                    endTime: current.endTime,
                 });
-                // CLEAR 期间显示为 START
+            } else {
                 Conditions.push({
-                    beginCondition: START.maxCondition,
-                    endCondition: START.maxCondition,
-                    forecastToken: "START",
-                    parameters: [{ date: START.startTime, type: "FIRST_AT" }],
-                    startTime: CLEAR.startTime, // CLEAR 期间
-                    endTime: CLEAR.endTime, // CLEAR 期间
-                });
-                // START 期间显示为 CONSTANT
-                Conditions.push({
-                    beginCondition: START.maxCondition,
-                    endCondition: START.maxCondition,
-                    forecastToken: "CONSTANT",
-                    parameters: [],
-                    startTime: START.startTime, // START 期间
-                    endTime: 0, // START 期间
-                });
-                break;
-            }
-            case "true|false|true": {
-                // 先 CLEAR 后降水, 再 CLEAR, 是 START_STOP
-                const CLEAR1 = summaries[0]; // START_STOP 时期
-                const STOP = summaries[1]; // STOP 时期
-                const CLEAR2 = summaries[2]; // CLEAR 时期
-                // CLEAR1 期间显示为 START_STOP
-                Conditions.push({
-                    beginCondition: STOP.maxCondition, // STOP 的开始天气
-                    endCondition: STOP.maxCondition, // STOP 的结束天气
-                    forecastToken: "START_STOP",
-                    parameters: [
-                        { date: STOP.startTime, type: "FIRST_AT" },
-                        { date: STOP.endTime, type: "SECOND_AT" },
-                    ],
-                    startTime: CLEAR1.startTime, // CLEAR1 期间
-                    endTime: CLEAR1.endTime, // CLEAR1 期间
-                });
-                // STOP 期间显示为 STOP
-                Conditions.push({
-                    beginCondition: STOP.maxCondition, // STOP 的开始天气
-                    endCondition: STOP.maxCondition, // STOP 的结束天气
+                    beginCondition: current.maxCondition,
+                    endCondition: current.maxCondition,
                     forecastToken: "STOP",
-                    parameters: [{ date: STOP.endTime, type: "FIRST_AT" }],
-                    startTime: STOP.startTime, // STOP 期间
-                    endTime: STOP.endTime, // STOP 期间
+                    parameters: [{ date: current.endTime, type: "FIRST_AT" }],
+                    startTime: current.startTime,
+                    endTime: current.endTime,
                 });
-                // CLEAR2 期间显示为 CLEAR
-                Conditions.push({
-                    beginCondition: CLEAR2.maxCondition, // CLEAR2 时期
-                    endCondition: CLEAR2.maxCondition, // CLEAR2 时期
-                    forecastToken: "CLEAR",
-                    parameters: [],
-                    startTime: CLEAR2.startTime, // CLEAR2 期间
-                    endTime: 0, // CLEAR2 期间
-                });
-                break;
-            }
-            case "false|true|false|true": {
-                // 先降水后 CLEAR, 再降水再 CLEAR, 是 STOP_START + START_STOP
-                const STOP1 = summaries[0]; // STOP 时期 1
-                const CLEAR1 = summaries[1]; // CLEAR 时期 1
-                const STOP2 = summaries[2]; // STOP 时期 2
-                const CLEAR2 = summaries[3]; // CLEAR 时期 2
-                // STOP1 期间显示为 STOP_START
-                Conditions.push({
-                    beginCondition: STOP1.maxCondition, // STOP1 的开始天气
-                    endCondition: STOP2.maxCondition, // STOP2 的开始天气
-                    forecastToken: "STOP_START",
-                    parameters: [
-                        { date: STOP1.endTime, type: "FIRST_AT" }, // STOP1 结束
-                        { date: STOP2.startTime, type: "SECOND_AT" }, // STOP2 开始
-                    ],
-                    startTime: STOP1.startTime, // STOP1 期间
-                    endTime: STOP1.endTime, // STOP1 期间
-                });
-                // CLEAR1 期间显示为 START_STOP
-                Conditions.push({
-                    beginCondition: STOP2.maxCondition, // STOP 时期 2
-                    endCondition: STOP2.maxCondition, // STOP 时期 2
-                    forecastToken: "START_STOP",
-                    parameters: [
-                        { date: STOP2.startTime, type: "FIRST_AT" }, // STOP2 开始
-                        { date: STOP2.endTime, type: "SECOND_AT" }, // STOP2 结束
-                    ],
-                    startTime: CLEAR1.startTime, // CLEAR1 期间
-                    endTime: CLEAR1.endTime, // CLEAR1 期间
-                });
-                // STOP2 期间显示为 STOP
-                Conditions.push({
-                    beginCondition: STOP2.maxCondition, // STOP 时期
-                    endCondition: STOP2.maxCondition, // STOP 时期
-                    forecastToken: "STOP",
-                    parameters: [{ date: STOP2.endTime, type: "FIRST_AT" }],
-                    startTime: STOP2.startTime, // STOP2 期间
-                    endTime: STOP2.endTime, // STOP2 期间
-                });
-                // CLEAR2 期间显示为 CLEAR
-                Conditions.push({
-                    beginCondition: CLEAR2.maxCondition, // CLEAR 时期
-                    endCondition: CLEAR2.maxCondition, // CLEAR 时期
-                    forecastToken: "CLEAR",
-                    parameters: [],
-                    startTime: CLEAR2.startTime, // CLEAR2 期间
-                    endTime: 0, // CLEAR2 期间
-                });
-                break;
-            }
-            case "true|false|true|false": {
-                // 先 CLEAR 后降水, 再 CLEAR 再降水, 是 START_STOP + STOP_START
-                const CLEAR1 = summaries[0]; // CLEAR1 时期
-                const START1 = summaries[1]; // START1 时期
-                const CLEAR2 = summaries[2]; // CLEAR2 时期
-                const START2 = summaries[3]; // START2 时期
-                // CLEAR1 期间显示为 START_STOP
-                Conditions.push({
-                    beginCondition: START1.maxCondition, // START1 的开始天气
-                    endCondition: START1.maxCondition, // START1 的结束天气
-                    forecastToken: "START_STOP",
-                    parameters: [
-                        { date: START1.startTime, type: "FIRST_AT" }, // CLEAR1 结束
-                        { date: START1.endTime, type: "SECOND_AT" }, // CLEAR2 开始
-                    ],
-                    startTime: CLEAR1.startTime, // CLEAR1 期间
-                    endTime: CLEAR1.endTime, // CLEAR1 期间
-                });
-                // START1 期间显示为 STOP_START
-                Conditions.push({
-                    beginCondition: START1.maxCondition, // START1 的结束天气
-                    endCondition: START2.maxCondition, // START2 的开始天气
-                    forecastToken: "STOP_START",
-                    parameters: [
-                        { date: START1.endTime, type: "FIRST_AT" }, // START1 结束
-                        { date: START2.startTime, type: "SECOND_AT" }, // START2 开始
-                    ],
-                    startTime: START1.startTime, // START1 期间
-                    endTime: START1.endTime, // START1 期间
-                });
-                // CLEAR2 期间显示为 START
-                Conditions.push({
-                    beginCondition: START2.maxCondition, // START2.beginCondition, // START2 的开始天气
-                    endCondition: START2.maxCondition, // START2 的开始天气
-                    forecastToken: "START",
-                    parameters: [{ date: START2.startTime, type: "FIRST_AT" }],
-                    startTime: CLEAR2.startTime, // CLEAR2 期间
-                    endTime: CLEAR2.endTime, // CLEAR2 期间
-                });
-                // START2 期间显示为 CONSTANT
-                Conditions.push({
-                    beginCondition: START2.maxCondition, // START2 时期
-                    endCondition: START2.maxCondition, // START2 时期
-                    forecastToken: "CONSTANT",
-                    parameters: [],
-                    startTime: START2.startTime, // START2 期间
-                    endTime: 0, // START2 期间
-                });
-                break;
             }
         }
         Console.debug(`Conditions: ${JSON.stringify(Conditions, null, 2)}`);

--- a/tests/forecastNextHour.test.mjs
+++ b/tests/forecastNextHour.test.mjs
@@ -1,0 +1,290 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import ForecastNextHour from "../src/class/ForecastNextHour.mjs";
+
+const BASE_TIME = 1_700_000_000;
+const INTERVAL = 10 * 60;
+const RAIN_CONDITIONS = ["DRIZZLE", "RAIN", "HEAVY_RAIN"];
+
+test("Condition preserves every existing one-to-four segment output", () => {
+    const cases = [
+        ["C", [["CLEAR", 0, 0]]],
+        ["R", [["CONSTANT", 0, 0]]],
+        [
+            "CR",
+            [
+                ["START", 1, 1, [["FIRST_AT", 1, "startTime"]]],
+                ["CONSTANT", 1, 1],
+            ],
+        ],
+        [
+            "RC",
+            [
+                ["STOP", 0, 0, [["FIRST_AT", 0, "endTime"]]],
+                ["CLEAR", 1, 1],
+            ],
+        ],
+        [
+            "RCR",
+            [
+                [
+                    "STOP_START",
+                    0,
+                    2,
+                    [
+                        ["FIRST_AT", 0, "endTime"],
+                        ["SECOND_AT", 2, "startTime"],
+                    ],
+                ],
+                ["START", 2, 2, [["FIRST_AT", 2, "startTime"]]],
+                ["CONSTANT", 2, 2],
+            ],
+        ],
+        [
+            "CRC",
+            [
+                [
+                    "START_STOP",
+                    1,
+                    1,
+                    [
+                        ["FIRST_AT", 1, "startTime"],
+                        ["SECOND_AT", 1, "endTime"],
+                    ],
+                ],
+                ["STOP", 1, 1, [["FIRST_AT", 1, "endTime"]]],
+                ["CLEAR", 2, 2],
+            ],
+        ],
+        [
+            "RCRC",
+            [
+                [
+                    "STOP_START",
+                    0,
+                    2,
+                    [
+                        ["FIRST_AT", 0, "endTime"],
+                        ["SECOND_AT", 2, "startTime"],
+                    ],
+                ],
+                [
+                    "START_STOP",
+                    2,
+                    2,
+                    [
+                        ["FIRST_AT", 2, "startTime"],
+                        ["SECOND_AT", 2, "endTime"],
+                    ],
+                ],
+                ["STOP", 2, 2, [["FIRST_AT", 2, "endTime"]]],
+                ["CLEAR", 3, 3],
+            ],
+        ],
+        [
+            "CRCR",
+            [
+                [
+                    "START_STOP",
+                    1,
+                    1,
+                    [
+                        ["FIRST_AT", 1, "startTime"],
+                        ["SECOND_AT", 1, "endTime"],
+                    ],
+                ],
+                [
+                    "STOP_START",
+                    1,
+                    3,
+                    [
+                        ["FIRST_AT", 1, "endTime"],
+                        ["SECOND_AT", 3, "startTime"],
+                    ],
+                ],
+                ["START", 3, 3, [["FIRST_AT", 3, "startTime"]]],
+                ["CONSTANT", 3, 3],
+            ],
+        ],
+        [
+            "RCRCRC",
+            [
+                [
+                    "STOP_START",
+                    0,
+                    2,
+                    [
+                        ["FIRST_AT", 0, "endTime"],
+                        ["SECOND_AT", 2, "startTime"],
+                    ],
+                ],
+                [
+                    "START_STOP",
+                    2,
+                    2,
+                    [
+                        ["FIRST_AT", 2, "startTime"],
+                        ["SECOND_AT", 2, "endTime"],
+                    ],
+                ],
+                [
+                    "STOP_START",
+                    2,
+                    4,
+                    [
+                        ["FIRST_AT", 2, "endTime"],
+                        ["SECOND_AT", 4, "startTime"],
+                    ],
+                ],
+                [
+                    "START_STOP",
+                    4,
+                    4,
+                    [
+                        ["FIRST_AT", 4, "startTime"],
+                        ["SECOND_AT", 4, "endTime"],
+                    ],
+                ],
+                ["STOP", 4, 4, [["FIRST_AT", 4, "endTime"]]],
+                ["CLEAR", 5, 5],
+            ],
+        ],
+        [
+            "CRCRCR",
+            [
+                [
+                    "START_STOP",
+                    1,
+                    1,
+                    [
+                        ["FIRST_AT", 1, "startTime"],
+                        ["SECOND_AT", 1, "endTime"],
+                    ],
+                ],
+                [
+                    "STOP_START",
+                    1,
+                    3,
+                    [
+                        ["FIRST_AT", 1, "endTime"],
+                        ["SECOND_AT", 3, "startTime"],
+                    ],
+                ],
+                [
+                    "START_STOP",
+                    3,
+                    3,
+                    [
+                        ["FIRST_AT", 3, "startTime"],
+                        ["SECOND_AT", 3, "endTime"],
+                    ],
+                ],
+                [
+                    "STOP_START",
+                    3,
+                    5,
+                    [
+                        ["FIRST_AT", 3, "endTime"],
+                        ["SECOND_AT", 5, "startTime"],
+                    ],
+                ],
+                ["START", 5, 5, [["FIRST_AT", 5, "startTime"]]],
+                ["CONSTANT", 5, 5],
+            ],
+        ],
+    ];
+
+    for (const [pattern, specs] of cases) {
+        const summaries = makeSummaries(pattern);
+        assert.deepEqual(ForecastNextHour.Condition(summaries), materializeConditions(summaries, specs), pattern);
+    }
+});
+
+test("Condition supports one-to-ten alternating segments without dropping the product", () => {
+    for (const first of ["C", "R"]) {
+        for (let length = 1; length <= 10; length++) {
+            const pattern = Array.from({ length }, (_, index) => (index % 2 === 0 ? first : first === "C" ? "R" : "C")).join("");
+            const summaries = makeSummaries(pattern);
+            const conditions = ForecastNextHour.Condition(summaries);
+
+            assert.equal(conditions.length, summaries.length, pattern);
+            assert.deepEqual(
+                conditions.map(condition => condition.forecastToken),
+                expectedTokens(pattern),
+                pattern,
+            );
+            conditions.forEach((condition, index) => {
+                assert.equal(condition.startTime, summaries[index].startTime, `${pattern}[${index}] startTime`);
+                assert.equal(condition.endTime, summaries[index].endTime, `${pattern}[${index}] endTime`);
+                assert.equal(condition.parameters.length, parameterCount(condition.forecastToken), `${pattern}[${index}] parameters`);
+                if (condition.parameters.length === 2) {
+                    assert.ok(condition.parameters[0].date < condition.parameters[1].date, `${pattern}[${index}] parameter order`);
+                }
+            });
+        }
+    }
+});
+
+test("Minute to Summary to Condition retains six intermittent rain segments", () => {
+    const minutes = Array.from({ length: 71 }, (_, index) => {
+        const raining = index < 10 || (index >= 20 && index < 30) || (index >= 40 && index < 50);
+        return {
+            precipitationChance: 100,
+            precipitationIntensity: raining ? 1 : 0,
+            startTime: BASE_TIME + index * 60,
+        };
+    });
+
+    const normalized = ForecastNextHour.Minute(minutes, "未来两小时有间歇性小雨");
+    const summaries = ForecastNextHour.Summary(normalized);
+    const conditions = ForecastNextHour.Condition(summaries);
+
+    assert.deepEqual(
+        summaries.map(summary => summary.clear),
+        [false, true, false, true, false, true],
+    );
+    assert.deepEqual(
+        conditions.map(condition => condition.forecastToken),
+        ["STOP_START", "START_STOP", "STOP_START", "START_STOP", "STOP", "CLEAR"],
+    );
+    assert.equal(conditions.length, summaries.length);
+});
+
+test("Condition preserves empty output for missing or unsupported non-alternating summaries", () => {
+    assert.deepEqual(ForecastNextHour.Condition([]), []);
+    assert.deepEqual(ForecastNextHour.Condition(makeSummaries("RRC")), []);
+});
+
+function makeSummaries(pattern) {
+    return [...pattern].map((symbol, index) => ({
+        clear: symbol === "C",
+        endTime: index === pattern.length - 1 ? 0 : BASE_TIME + (index + 1) * INTERVAL,
+        maxCondition: symbol === "C" ? "CLEAR" : RAIN_CONDITIONS[index % RAIN_CONDITIONS.length],
+        startTime: BASE_TIME + index * INTERVAL,
+    }));
+}
+
+function materializeConditions(summaries, specs) {
+    return specs.map(([forecastToken, beginIndex, endIndex, parameters = []], index) => ({
+        beginCondition: summaries[beginIndex].maxCondition,
+        endCondition: summaries[endIndex].maxCondition,
+        forecastToken,
+        parameters: parameters.map(([type, summaryIndex, field]) => ({ date: summaries[summaryIndex][field], type })),
+        startTime: summaries[index].startTime,
+        endTime: summaries[index].endTime,
+    }));
+}
+
+function expectedTokens(pattern) {
+    return [...pattern].map((symbol, index) => {
+        if (index === pattern.length - 1) return symbol === "C" ? "CLEAR" : "CONSTANT";
+        if (symbol === "C") return index + 2 < pattern.length ? "START_STOP" : "START";
+        return index + 2 < pattern.length ? "STOP_START" : "STOP";
+    });
+}
+
+function parameterCount(token) {
+    if (token === "START_STOP" || token === "STOP_START") return 2;
+    if (token === "START" || token === "STOP") return 1;
+    return 0;
+}


### PR DESCRIPTION
Refs #69
Refs #44

## 根因

`ForecastNextHour.Condition()` 原来把 `summary.clear` 拼成字符串，再匹配写死的 1–4 段模式。5 段以上的合法交替降水会直接落空，最终编码出空的 `condition` vector。

确定性回放结果很直接：六段 `RAIN/CLEAR` 输入会生成 6 个 summary，但旧实现输出 `Conditions: []`。macOS 27 Weather.app 因此隐藏整张下一小时降水卡片。问题出在通用 condition 生成器，不是 macOS 特有的数据格式。

## 修改

- 用线性 look-ahead 替换固定模式 switch。每段只查看当前、下一段和下下段，生成 `CLEAR`、`CONSTANT`、`START`、`STOP`、`START_STOP` 或 `STOP_START`。
- 保持原有 1–4 段输出逐字段不变，包括 condition、时间区间以及 `FIRST_AT`/`SECOND_AT` 参数。
- 支持任意长度的交替晴雨段，并把 `ForecastNextHour` 版本更新到 `v1.6.5`。

## 验证

- `node --test`：7/7 通过。专项测试覆盖旧 1–4 段、两种六段 golden、1–10 段性质检查，以及 `Minute`、`Summary`、`Condition` 六段链路。
- `node --check` 和 Biome 检查通过；Biome 仅报告 `Minute.map((minute, i))` 中已有的 unused-parameter warning。
- `npm run build:dev`、`npm run build` 通过。
- WeatherKit 27 FlatBuffer 回放从 41,472 bytes 编码为 43,912 bytes。六个 condition 反解为 `STOP_START, START_STOP, STOP_START, START_STOP, STOP, CLEAR`，与输入一致。
- Surge + macOS 27 Weather.app（26A5378n，海口）实测中，修复 bundle 命中完整 12-product 请求并替换 slot 4（NextHour）和 slot 0（AQ）。App 恢复显示 `降雨将短暂停止` 以及停止、再次开始时间。
- 同一请求仍输出 `EU.EAQI.2414`，`forecastNextHour` 和 `airQuality` 均成功编码，AQ 覆盖未受影响。

## macOS 复现

修复前，六段间歇降水已经生成分钟图数据，但 `condition` 为空，App 不显示下一小时卡片。

![macOS 修复前无下一小时卡片](https://github.com/user-attachments/assets/fe681175-391e-4608-9724-e490b852ec44)

修复后，实测多段降水能生成停止、再次开始语义，App 正常显示卡片。上面的 FlatBuffer 回放另行确认了同一六段模式的编码结果。

![macOS 修复后显示下一小时卡片](https://github.com/user-attachments/assets/9f55889d-0eda-41f1-b1a3-9f69d9d90dee)

同时并没有损伤桌面widgets 的正确显示
<img width="360" height="360" alt="image" src="https://github.com/user-attachments/assets/23fb0be5-a03e-4cfe-b10e-2d589e91f91b" />


## 边界

本 PR 只修复 condition 数量受限的问题。`Summary()` 最后一分钟的独立边界行为、未修改 product 的 selective decode，以及 macOS AQ scale 请求问题不在本次范围内。
