### PR TITLE
chore: use public npm registry for @nsnanocat/util

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
 registry=https://registry.npmjs.org/
-@nsnanocat:registry=https://npm.pkg.github.com/
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/package-lock.json
+++ b/package-lock.json
@@ -916,7 +916,7 @@
         },
         "node_modules/@nsnanocat/util": {
             "version": "2.2.3",
-            "resolved": "https://npm.pkg.github.com/download/@nsnanocat/util/2.2.3/982c1104645d9b0dc636a79d5ef8c7039e47f3c7",
+            "resolved": "https://registry.npmjs.org/@nsnanocat/util/-/util-2.2.3.tgz",
             "integrity": "sha512-923c7+xAI7cTy/HvEXvHtTWunBDwIwsFtcaOOAiFtZRlb/lmTtVDEL6PQGyirId5xEzSFRVUhzUFSJbylByjWg==",
             "license": "Apache-2.0"
         },


### PR DESCRIPTION
Refs [PR #69 review comment](https://github.com/NSRingo/WeatherKit/pull/69#issuecomment-4980026068).

## 修改

- 移除 `@nsnanocat` 的 GitHub Packages registry override 和 `NODE_AUTH_TOKEN` 配置。
- 保留 `@nsnanocat/util@2.2.3`，将 lockfile 的 tarball 地址改为 npmjs 公共地址。

## 验证

- `env -u NODE_AUTH_TOKEN npm ci --ignore-scripts --userconfig=/dev/null`
- `npm ls @nsnanocat/util --userconfig=/dev/null`：安装版本为 `2.2.3`。
- lockfile 只有 `@nsnanocat/util` 的 `resolved` 地址发生变化。

GitHub CLI 显示 `hhh2210` 是 NSRingo 的 active direct member，但此仓库的 `viewerPermission` 仍是 `READ`，因此分支从 fork 提交。
