### PR TITLE
refactor(WeatherKit2): decode only injectable products

### DIFF
--- a/src/class/WeatherKit2.mjs
+++ b/src/class/WeatherKit2.mjs
@@ -486,30 +486,43 @@ export default class WeatherKit2 {
 
     static decode(byteBuffer, dataSet = "all", data = {}) {
         Console.info("☑️ WeatherKit2.decode", `dataSet: ${dataSet}`);
-        const Weather = WK2.Weather.getRootAsWeather(byteBuffer);
-        const AirQualityData = Weather?.airQuality();
-        const CurrentWeatherData = Weather?.currentWeather();
-        const DailyForecastData = Weather?.forecastDaily();
-        const HourlyForecastData = Weather?.forecastHourly();
-        const NextHourForecastData = Weather?.forecastNextHour();
-        const NewsData = Weather?.news();
-        const WeatherAlertCollectionData = Weather?.weatherAlerts();
-        const WeatherChangesData = Weather?.weatherChanges();
-        const HistoricalComparisonsData = Weather?.historicalComparisons();
-        const LocationInfoData = Weather?.locationInfo();
+        const requestedDataSets = typeof dataSet === "string" ? null : new Set([...dataSet].filter(name => WeatherKit2.InjectableRootSlots.has(name)));
+        if (dataSet === "all" || requestedDataSets) {
+            const Weather = WK2.Weather.getRootAsWeather(byteBuffer);
+            const decodeRootDataSet = (name, accessor, decoder = name, target = name) => {
+                if (requestedDataSets && !requestedDataSets.has(name)) return;
+                const rootData = accessor();
+                if (rootData) data[target] = WeatherKit2.decode(byteBuffer, decoder, rootData);
+            };
+
+            decodeRootDataSet("airQuality", () => Weather?.airQuality());
+            decodeRootDataSet("currentWeather", () => Weather?.currentWeather());
+            decodeRootDataSet("forecastDaily", () => Weather?.forecastDaily());
+            decodeRootDataSet("forecastHourly", () => Weather?.forecastHourly());
+            decodeRootDataSet("forecastNextHour", () => Weather?.forecastNextHour());
+            decodeRootDataSet("news", () => Weather?.news());
+            decodeRootDataSet("weatherAlerts", () => Weather?.weatherAlerts());
+            decodeRootDataSet("weatherChanges", () => Weather?.weatherChanges(), "weatherChange");
+            decodeRootDataSet("historicalComparisons", () => Weather?.historicalComparisons(), "trendComparison");
+            decodeRootDataSet("locationInfo", () => Weather?.locationInfo());
+
+            Console.info("✅ WeatherKit2.decode", `dataSet: ${dataSet}`);
+            return data;
+        }
+
+        const Weather = data?.bb || dataSet === "metadata" ? undefined : WK2.Weather.getRootAsWeather(byteBuffer);
+        const rootData = data?.bb ? data : undefined;
+        const AirQualityData = dataSet === "airQuality" ? (rootData ?? Weather?.airQuality()) : undefined;
+        const CurrentWeatherData = dataSet === "currentWeather" ? (rootData ?? Weather?.currentWeather()) : undefined;
+        const DailyForecastData = dataSet === "forecastDaily" ? (rootData ?? Weather?.forecastDaily()) : undefined;
+        const HourlyForecastData = dataSet === "forecastHourly" ? (rootData ?? Weather?.forecastHourly()) : undefined;
+        const NextHourForecastData = dataSet === "forecastNextHour" ? (rootData ?? Weather?.forecastNextHour()) : undefined;
+        const NewsData = dataSet === "news" ? (rootData ?? Weather?.news()) : undefined;
+        const WeatherAlertCollectionData = dataSet === "weatherAlert" || dataSet === "weatherAlerts" ? (rootData ?? Weather?.weatherAlerts()) : undefined;
+        const WeatherChangesData = dataSet === "weatherChange" || dataSet === "weatherChanges" ? (rootData ?? Weather?.weatherChanges()) : undefined;
+        const HistoricalComparisonsData = ["trendComparison", "trendComparisons", "historicalComparison", "historicalComparisons"].includes(dataSet) ? (rootData ?? Weather?.historicalComparisons()) : undefined;
+        const LocationInfoData = dataSet === "locationInfo" ? (rootData ?? Weather?.locationInfo()) : undefined;
         switch (dataSet) {
-            case "all":
-                if (AirQualityData) data.airQuality = WeatherKit2.decode(byteBuffer, "airQuality", AirQualityData);
-                if (CurrentWeatherData) data.currentWeather = WeatherKit2.decode(byteBuffer, "currentWeather", CurrentWeatherData);
-                if (DailyForecastData) data.forecastDaily = WeatherKit2.decode(byteBuffer, "forecastDaily", DailyForecastData);
-                if (HourlyForecastData) data.forecastHourly = WeatherKit2.decode(byteBuffer, "forecastHourly", HourlyForecastData);
-                if (NextHourForecastData) data.forecastNextHour = WeatherKit2.decode(byteBuffer, "forecastNextHour", NextHourForecastData);
-                if (NewsData) data.news = WeatherKit2.decode(byteBuffer, "news", NewsData);
-                if (WeatherAlertCollectionData) data.weatherAlerts = WeatherKit2.decode(byteBuffer, "weatherAlerts", WeatherAlertCollectionData);
-                if (WeatherChangesData) data.weatherChanges = WeatherKit2.decode(byteBuffer, "weatherChange", WeatherChangesData);
-                if (HistoricalComparisonsData) data.historicalComparisons = WeatherKit2.decode(byteBuffer, "trendComparison", HistoricalComparisonsData);
-                if (LocationInfoData) data.locationInfo = WeatherKit2.decode(byteBuffer, "locationInfo", LocationInfoData);
-                break;
             case "airQuality":
                 data = {
                     metadata: WeatherKit2.decode(byteBuffer, "metadata", AirQualityData?.metadata()),

--- a/src/process/Response.dev.mjs
+++ b/src/process/Response.dev.mjs
@@ -97,12 +97,12 @@ export async function Response($request, $response) {
                         case "weatherkit.apple.com":
                             // 路径判断
                             if (url.pathname.startsWith("/api/v2/weather/")) {
-                                body = WeatherKit2.decode(ByteBuffer, "all");
+                                const parameters = parseWeatherKitURL(url);
+                                body = WeatherKit2.decode(ByteBuffer, parameters.dataSets);
                                 const matchEnum = new MatchEnum(body);
                                 if (Settings?.LogLevel === "DEBUG" || Settings?.LogLevel === "ALL") {
                                     await matchEnum.init();
                                 }
-                                const parameters = parseWeatherKitURL(url);
                                 const originalForecastNextHour = body.forecastNextHour;
                                 const replacementDataSets = new Set();
                                 const enviroments = {
@@ -204,13 +204,15 @@ export async function Response($request, $response) {
                                         }
                                     }),
                                 );
-                                const WeatherData = WeatherKit2.encodeRootOverlay(Builder, ByteBuffer, replacementDataSets, body);
-                                Builder.finish(WeatherData);
+                                if (replacementDataSets.size) {
+                                    const WeatherData = WeatherKit2.encodeRootOverlay(Builder, ByteBuffer, replacementDataSets, body);
+                                    Builder.finish(WeatherData);
+                                    rawBody = Builder.asUint8Array(); // Of type `Uint8Array`.
+                                }
                                 break;
                             }
                             break;
                     }
-                    rawBody = Builder.asUint8Array(); // Of type `Uint8Array`.
                     break;
                 }
                 case "application/protobuf":

--- a/src/process/Response.mjs
+++ b/src/process/Response.mjs
@@ -83,8 +83,8 @@ export async function Response($request, $response) {
                         case "weatherkit.apple.com":
                             // 路径判断
                             if (url.pathname.startsWith("/api/v2/weather/")) {
-                                body = WeatherKit2.decode(ByteBuffer, "all");
                                 const parameters = parseWeatherKitURL(url);
+                                body = WeatherKit2.decode(ByteBuffer, parameters.dataSets);
                                 const originalForecastNextHour = body.forecastNextHour;
                                 const replacementDataSets = new Set();
                                 const enviroments = {
@@ -140,13 +140,15 @@ export async function Response($request, $response) {
                                         }
                                     }),
                                 );
-                                const WeatherData = WeatherKit2.encodeRootOverlay(Builder, ByteBuffer, replacementDataSets, body);
-                                Builder.finish(WeatherData);
+                                if (replacementDataSets.size) {
+                                    const WeatherData = WeatherKit2.encodeRootOverlay(Builder, ByteBuffer, replacementDataSets, body);
+                                    Builder.finish(WeatherData);
+                                    rawBody = Builder.asUint8Array(); // Of type `Uint8Array`.
+                                }
                                 break;
                             }
                             break;
                     }
-                    rawBody = Builder.asUint8Array(); // Of type `Uint8Array`.
                     break;
                 }
                 case "application/protobuf":

--- a/tests/weatherKitSelectiveDecode.test.mjs
+++ b/tests/weatherKitSelectiveDecode.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Builder, ByteBuffer } from "flatbuffers";
+
+globalThis.$environment = { "surge-version": "test" };
+globalThis.$persistentStore = { read: () => null, write: () => true };
+globalThis.$argument = { LogLevel: "OFF", Storage: "database" };
+
+const [{ default: WeatherKit2 }, { Weather }, { Response }] = await Promise.all([import("../src/class/WeatherKit2.mjs"), import("../src/proto/apple/wk2.js"), import("../src/process/Response.mjs")]);
+
+const injectableDataSets = ["airQuality", "currentWeather", "forecastDaily", "forecastHourly", "forecastNextHour"];
+const unrelatedKnownDataSets = ["news", "weatherAlerts", "weatherChanges", "historicalComparisons", "locationInfo"];
+
+test("selected root decode never opens unrelated known products", () => {
+    const sourceBytes = createWeatherRoot([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    const allDecoded = WeatherKit2.decode(new ByteBuffer(sourceBytes), "all");
+    const originalDecode = WeatherKit2.decode;
+    const decodeCalls = [];
+    const originalAccessors = new Map();
+
+    WeatherKit2.decode = function (...args) {
+        decodeCalls.push(args[1]);
+        return originalDecode.apply(this, args);
+    };
+    for (const accessor of ["news", "weatherAlerts", "weatherChanges", "historicalComparisons", "locationInfo"]) {
+        originalAccessors.set(accessor, Weather.prototype[accessor]);
+        Weather.prototype[accessor] = () => {
+            throw new Error(`unexpected root accessor: ${accessor}`);
+        };
+    }
+
+    try {
+        const decoded = WeatherKit2.decode(new ByteBuffer(sourceBytes), [...injectableDataSets, ...unrelatedKnownDataSets]);
+        assert.deepEqual(Object.keys(decoded), injectableDataSets);
+        for (const dataSet of injectableDataSets) assert.deepEqual(decoded[dataSet], allDecoded[dataSet]);
+    } finally {
+        WeatherKit2.decode = originalDecode;
+        for (const [accessor, implementation] of originalAccessors) Weather.prototype[accessor] = implementation;
+    }
+
+    const decodedProducts = decodeCalls.filter(call => typeof call === "string" && call !== "metadata");
+    assert.deepEqual(decodedProducts, injectableDataSets);
+});
+
+test("response returns the original bytes when selected products produce no replacement", async () => {
+    const originalBytes = createWeatherRoot([4, 5]);
+    const response = await Response(
+        {
+            url: "https://weatherkit.apple.com/api/v2/weather/en-US/22.5431/114.0579?country=US&dataSets=forecastNextHour,news",
+        },
+        {
+            bodyBytes: originalBytes,
+            headers: { "Content-Type": "application/vnd.apple.flatbuffer" },
+        },
+    );
+
+    assert.deepEqual(new Uint8Array(response.body), originalBytes);
+});
+
+function createWeatherRoot(presentSlots) {
+    const builder = new Builder(256);
+    const tables = new Map(presentSlots.map(slot => [slot, createEmptyTable(builder)]));
+    builder.startObject(10);
+    for (const [slot, offset] of tables) builder.addFieldOffset(slot, offset, 0);
+    const root = builder.endObject();
+    builder.finish(root);
+    return builder.asUint8Array().slice();
+}
+
+function createEmptyTable(builder) {
+    builder.startObject(0);
+    return builder.endObject();
+}


### PR DESCRIPTION
Refs https://github.com/NSRingo/WeatherKit/pull/69#issuecomment-4979985403

## 背景

#69 已经在编码阶段只重建实际修改的 root products，其余 slots 保持 opaque。但响应入口仍调用 `decode("all")`，所以没有修改计划的产品仍会经过旧 schema 解析。

## 修改

- `WeatherKit2.decode` 现在可以接收请求中的 `dataSets`，并只解析插件可覆盖的五类产品：`airQuality`、`currentWeather`、`forecastDaily`、`forecastHourly` 和 `forecastNextHour`。
- `Response.mjs` 与 `Response.dev.mjs` 在解码前解析 URL，并把请求的 `dataSets` 传入解码器。`decode("all")` 的原有调用方式保持兼容。
- 如果这一轮没有任何 replacement，响应直接返回原始 FlatBuffer 字节，不再执行无意义的 overlay 编码。

未修改产品仍由 #69 的 root overlay 作为 opaque tables 保留，不需要依赖当前仓库中的 schema。

## 验证

- `node --test tests/weatherKitSelectiveDecode.test.mjs tests/flatBufferRootOverlay.test.mjs`
- `node --check src/class/WeatherKit2.mjs`
- `npx biome check src/class/WeatherKit2.mjs src/process/Response.mjs src/process/Response.dev.mjs tests/weatherKitSelectiveDecode.test.mjs`
- `npm run build`
- `npm run build:dev`

测试覆盖选择性解码不会访问未修改产品、五类可覆盖产品的结果与 `decode("all")` 一致，以及零 replacement 时返回的字节与原响应完全相同。

## 权限说明

GitHub API 显示当前账号的组织成员状态为 `active/member`，但 `NSRingo/WeatherKit` 的 `viewerPermission` 仍是 `READ`。因此这个 PR 继续从 `hhh2210` fork 提交。
