### PR TITLE
fix(forecastDaily): preserve paired precipitation totals

### DIFF
--- a/src/class/ColorfulClouds.mjs
+++ b/src/class/ColorfulClouds.mjs
@@ -313,7 +313,8 @@ export default class ColorfulClouds {
                                     // moonPhase: "", // Not given
                                     // moonrise: body?.result?.daily?.astro?.[i].sunset.time, // Not given
                                     // moonset: body?.result?.daily?.astro?.[i].sunrise.time, // Not given
-                                    precipitationAmount: body?.result?.daily?.precipitation?.[i]?.avg,
+                                    // Caiyun `avg` is an average rate (mm/h), not WeatherKit's accumulated amount (mm).
+                                    // Leave both amount fields absent so the merge keeps Apple's paired scalar/by-type totals.
                                     // precipitationAmountByType: [], // Not given
                                     precipitationChance: body?.result?.daily?.precipitation?.[i]?.probability,
                                     // precipitationType: "", // Not given
@@ -347,7 +348,7 @@ export default class ColorfulClouds {
                                         conditionCode: Weather.ConvertWeatherCode(body?.result?.daily?.skycon_08h_20h?.[i]?.value),
                                         // humidityMax: Math.round(body?.result?.daily?.humidity?.[i]?.max * 100), // Not given
                                         // humidityMin: Math.round(body?.result?.daily?.humidity?.[i]?.min * 100), // Not given
-                                        precipitationAmount: body?.result?.daily?.precipitation_08h_20h?.[i]?.avg,
+                                        // Caiyun `avg` is mm/h and cannot replace WeatherKit's accumulated precipitation total.
                                         // precipitationAmountByType: [], // Not given
                                         precipitationChance: body?.result?.daily?.precipitation_08h_20h?.[i]?.probability,
                                         // precipitationType: "", // Not given
@@ -371,7 +372,7 @@ export default class ColorfulClouds {
                                         conditionCode: Weather.ConvertWeatherCode(body?.result?.daily?.skycon_20h_32h?.[i]?.value),
                                         // humidityMax: Math.round(body?.result?.daily?.humidity?.[i]?.max * 100), // Not given
                                         // humidityMin: Math.round(body?.result?.daily?.humidity?.[i]?.min * 100), // Not given
-                                        precipitationAmount: body?.result?.daily?.precipitation_20h_32h?.[i]?.avg,
+                                        // Caiyun `avg` is mm/h and cannot replace WeatherKit's accumulated precipitation total.
                                         // precipitationAmountByType: [], // Not given
                                         precipitationChance: body?.result?.daily?.precipitation_20h_32h?.[i]?.probability,
                                         // precipitationType: "", // Not given

--- a/src/class/QWeather.mjs
+++ b/src/class/QWeather.mjs
@@ -515,7 +515,8 @@ export default class QWeather {
                                 moonPhase: Weather.ConvertMoonPhase(daily?.moonPhase),
                                 moonrise: this.#ConvertTimeStamp(daily?.fxDate, daily?.moonrise),
                                 moonset: this.#ConvertTimeStamp(daily?.fxDate, daily?.moonset),
-                                precipitationAmount: Number.parseFloat(daily?.precip),
+                                // QWeather does not provide WeatherKit's paired by-type totals.
+                                // Keep Apple's scalar/by-type amount pair atomic during the merge.
                                 // precipitationAmountByType: [], // Not given
                                 // precipitationChance: 0, // Not given
                                 // precipitationType: "", // Not given
@@ -550,7 +551,7 @@ export default class QWeather {
                                     // humidity 用一整天的数据代替
                                     // humidityMax: daily?.humidity, // Not Accurate
                                     // humidityMin: daily?.humidity, // Not Accurate
-                                    precipitationAmount: Number.parseFloat(daily?.precip),
+                                    // The daily total cannot be reused as a daytime-only accumulated amount.
                                     // precipitationAmountByType: [], // Not given
                                     // precipitationChance: 0, // Not given
                                     // precipitationType: "", // Not given
@@ -576,7 +577,7 @@ export default class QWeather {
                                     // humidity 用一整天的数据代替
                                     // humidityMax: daily?.humidity, // Not Accurate
                                     // humidityMin: daily?.humidity, // Not Accurate
-                                    precipitationAmount: Number.parseFloat(daily?.precip),
+                                    // The daily total cannot be reused as an overnight-only accumulated amount.
                                     // precipitationAmountByType: [], // Not given
                                     // precipitationChance: 0, // Not given
                                     // precipitationType: "", // Not given

--- a/tests/dailyPrecipitationTotals.test.mjs
+++ b/tests/dailyPrecipitationTotals.test.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+globalThis.$environment = { "surge-version": "test" };
+globalThis.$persistentStore = { read: () => null, write: () => true };
+globalThis.$argument = { LogLevel: "OFF", Storage: "database" };
+globalThis.$httpClient = {
+    get(request, callback) {
+        let body;
+        if (request.url.includes("api.caiyunapp.com")) body = colorfulCloudsDaily;
+        else if (request.url.includes("/v7/weather/")) body = qWeatherDaily;
+        else throw new Error(`unexpected request: ${request.url}`);
+        callback(null, { headers: {}, status: 200 }, JSON.stringify(body));
+    },
+};
+
+const [{ default: ColorfulClouds }, { default: QWeather }, { default: Weather }, { Console }] = await Promise.all([import("../src/class/ColorfulClouds.mjs"), import("../src/class/QWeather.mjs"), import("../src/class/Weather.mjs"), import("@nsnanocat/util")]);
+Console.logLevel = "OFF";
+
+const parameters = {
+    country: "CN",
+    language: "zh-Hans",
+    latitude: 22.537,
+    longitude: 113.899,
+    version: "v2",
+};
+
+test("ColorfulClouds keeps WeatherKit daily amount pairs while replacing supported fields", async () => {
+    const forecast = await new ColorfulClouds(parameters, "token").Daily(1);
+    const providerDay = forecast.days[0];
+
+    assertProviderDoesNotSupplyUnpairedAmounts(providerDay);
+    const appleDay = mergeIntoAppleDay(providerDay);
+    assertAppleAmountPairsRemainIntact(appleDay);
+    assert.equal(appleDay.precipitationChance, 80);
+    assert.equal(appleDay.daytimeForecast.precipitationChance, 70);
+    assert.equal(appleDay.overnightForecast.precipitationChance, 60);
+});
+
+test("QWeather keeps WeatherKit daily amount pairs instead of reusing one daily total", async () => {
+    const forecast = await new QWeather(parameters, "token").Daily(10);
+    const providerDay = forecast.days[0];
+
+    assertProviderDoesNotSupplyUnpairedAmounts(providerDay);
+    const appleDay = mergeIntoAppleDay(providerDay);
+    assertAppleAmountPairsRemainIntact(appleDay);
+    assert.equal(appleDay.daytimeForecast.conditionCode, "RAIN");
+    assert.equal(appleDay.overnightForecast.conditionCode, "CLOUDY");
+});
+
+function assertProviderDoesNotSupplyUnpairedAmounts(day) {
+    assert.equal(Object.hasOwn(day, "precipitationAmount"), false);
+    assert.equal(Object.hasOwn(day.daytimeForecast, "precipitationAmount"), false);
+    assert.equal(Object.hasOwn(day.overnightForecast, "precipitationAmount"), false);
+}
+
+function mergeIntoAppleDay(providerDay) {
+    const appleDay = {
+        forecastStart: providerDay.forecastStart,
+        precipitationAmount: 19,
+        precipitationAmountByType: [{ expected: 19, precipitationType: "RAIN" }],
+        daytimeForecast: {
+            precipitationAmount: 3,
+            precipitationAmountByType: [{ expected: 3, precipitationType: "RAIN" }],
+        },
+        overnightForecast: {
+            precipitationAmount: 16,
+            precipitationAmountByType: [{ expected: 16, precipitationType: "RAIN" }],
+        },
+    };
+    Weather.mergeForecast([appleDay], [providerDay]);
+    return appleDay;
+}
+
+function assertAppleAmountPairsRemainIntact(day) {
+    assert.equal(day.precipitationAmount, day.precipitationAmountByType[0].expected);
+    assert.equal(day.daytimeForecast.precipitationAmount, day.daytimeForecast.precipitationAmountByType[0].expected);
+    assert.equal(day.overnightForecast.precipitationAmount, day.overnightForecast.precipitationAmountByType[0].expected);
+}
+
+const colorfulCloudsDaily = {
+    location: [113.899, 22.537],
+    result: {
+        daily: {
+            cloudrate: [{ avg: 0.8 }],
+            humidity: [{ max: 0.9, min: 0.7 }],
+            precipitation: [{ avg: 1, probability: 80 }],
+            precipitation_08h_20h: [{ avg: 2, probability: 70 }],
+            precipitation_20h_32h: [{ avg: 3, probability: 60 }],
+            skycon: [{ date: "2026-07-16T00:00:00+08:00", value: "RAIN" }],
+            skycon_08h_20h: [{ value: "RAIN" }],
+            skycon_20h_32h: [{ value: "CLOUDY" }],
+            status: "ok",
+            temperature: [{ max: 30, min: 25 }],
+            temperature_08h_20h: [{ max: 30, min: 27 }],
+            temperature_20h_32h: [{ max: 28, min: 25 }],
+            visibility: [{ max: 20, min: 5 }],
+            wind: [{ avg: { speed: 3 }, max: { speed: 5 } }],
+            wind_08h_20h: [{ avg: { direction: 180, speed: 3 }, max: { speed: 5 } }],
+            wind_20h_32h: [{ avg: { direction: 200, speed: 2 }, max: { speed: 4 } }],
+        },
+    },
+    server_time: 1_784_167_551,
+    status: "ok",
+};
+
+const qWeatherDaily = {
+    code: "200",
+    daily: [
+        {
+            fxDate: "2026-07-16",
+            moonPhase: "满月",
+            moonrise: "20:00",
+            moonset: "06:00",
+            precip: "1.0",
+            sunrise: "05:48",
+            sunset: "19:10",
+            tempMax: "30",
+            tempMin: "25",
+            textDay: "中雨",
+            textNight: "阴",
+            uvIndex: "5",
+            wind360Day: "180",
+            wind360Night: "200",
+            windSpeedDay: "3",
+            windSpeedNight: "2",
+        },
+    ],
+    fxLink: "https://www.qweather.com/",
+    updateTime: "2026-07-16T08:00:00+08:00",
+};


### PR DESCRIPTION
Follow-up to #69

## 根因

在 iOS 27 真机验收中，逐日列表显示约 1–2 mm，但同一天的降水详情仍显示 `RAIN 19 mm`。这是 response rewrite 生成了不一致的 WeatherKit 字段，不是 Weather UI 的单位换算问题。

修复前截图：同一页面顶部的全天降水总量为 `2 mm`，底部按类型统计的降雨量为 `19 mm`。

![iOS Weather shows 2 mm daily total but 19 mm rain by type](https://github.com/user-attachments/assets/a0009d0e-5987-4b67-b4e5-fe625632121b)

- ColorfulClouds 把 `daily.precipitation.avg`（mm/h 平均速率）写入 `precipitationAmount`（mm 累计量）。
- QWeather 只提供日累计量，没有配套的 `precipitationAmountByType`，而且原实现把同一个日总量用于 day、daytime 和 overnight。
- `Weather.mergeForecast` 会覆盖第三方 provider 提供的 scalar，但保留 Apple 原有的 by-type 数据。最终同一天同时存在 `precipitationAmount: 1` 和 `RAIN: 19`，不同 UI 读取不同字段后便出现数值分裂。

## 修改

- ColorfulClouds 不再用平均速率覆盖 day、daytime、overnight 的累计降水量。
- QWeather 在无法提供配套 by-type 数据时，不再单独覆盖这三个 scalar。
- 降水概率、天气状况、温度和风等 provider 可以可靠提供的字段仍按现有逻辑合并。
- 新增两个 provider 的回归测试，验证 merge 后 day、daytime、overnight 的 scalar 与 by-type 仍保持成对一致。

## 验证

- `node --test tests/dailyPrecipitationTotals.test.mjs`：2/2 通过
- `node --test`：11/11 通过
- `node --check`（两个 provider 和新增测试）及 `git diff --check`：通过
- `npx biome check tests/dailyPrecipitationTotals.test.mjs`：通过
- `npm run build:dev`：通过
- `npm run build`：通过

## 外部部署检查

这个 head commit 触发了两个同名的 Cloudflare Worker 项目：[一个部署成功](https://github.com/NSRingo/WeatherKit/pull/73#issuecomment-4987610614)，[另一个部署失败](https://github.com/NSRingo/WeatherKit/pull/73#issuecomment-4987614128)。失败项目的行为与仍在使用 Cloudflare 默认非生产分支命令一致。仓库拆分配置后，默认 `wrangler.jsonc` 属于 Pages；本地执行 `wrangler versions upload --dry-run` 会复现 `Missing entry-point`，显式加上 `-c wrangler.workers.jsonc` 后通过。

Cloudflare Pages 从引入它的 `13111a6` 开始就持续失败，#69–#72 合入 `dev` 后也都是 Pages 失败，但 GitHub build、Gist deploy 和主 Worker 部署成功。本 PR 没有修改 Cloudflare 配置；Pages dashboard 没有向 GitHub 公开具体错误行。

回归用例还确认了 ColorfulClouds 的降水概率和 QWeather 的天气状况仍会正常覆盖，避免把这次修复扩大成禁用 provider 的逐日预报。
